### PR TITLE
V highlighting: keyword `as`, constant `none` - not a type

### DIFF
--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -308,7 +308,7 @@
 						},
 						{
 							"name": "keyword.control.v",
-							"match": "\\b(in|is|or|break|continue|default|unsafe|match|if|else|for|go|goto|defer|return)\\b(?=\\s*\\()"
+							"match": "\\b(as|in|is|or|break|continue|default|unsafe|match|if|else|for|go|goto|defer|return)\\b(?=\\s*\\()"
 						}
 					]
 				},
@@ -324,7 +324,7 @@
 							"name": "meta.expr.numeric.cast.v"
 						},
 						{
-							"match": "(bool|byte|byteptr|charptr|voidptr|string|ustring|rune|none)(?=\\s*\\()",
+							"match": "(bool|byte|byteptr|charptr|voidptr|string|ustring|rune)(?=\\s*\\()",
 							"captures": {
 								"1": {
 									"name": "storage.type.$1.v"
@@ -338,7 +338,7 @@
 		},
 		"escaped-fix": {
 			"name": "meta.escaped.keyword.v",
-			"match": "((?:@)(?:mut|var|pub|fn|unsafe|module|import|as|const|map|assert|sizeof|type|struct|interface|enum|in|is|or|match|if|else|for|go|goto|defer|return|i?(?:8|16|nt|64|128)|u?(?:16|32|64|128)|f?(?:32|64)|bool|byte|byteptr|charptr|voidptr|string|ustring|rune|none))",
+			"match": "((?:@)(?:mut|var|pub|fn|unsafe|module|import|as|const|map|assert|sizeof|type|struct|interface|enum|in|is|or|match|if|else|for|go|goto|defer|return|i?(?:8|16|nt|64|128)|u?(?:16|32|64|128)|f?(?:32|64)|bool|byte|byteptr|charptr|voidptr|string|ustring|rune))",
 			"captures": {
 				"0": {
 					"name": "keyword.other.escaped.v"
@@ -381,7 +381,7 @@
 		},
 		"constants": {
 			"name": "constant.language.v",
-			"match": "\\b(true|false)\\b"
+			"match": "\\b(true|false|none)\\b"
 		},
 		"generic": {
 			"patterns": [
@@ -815,7 +815,7 @@
 				},
 				{
 					"name": "keyword.control.v",
-					"match": "\\b(it|is|in|or|break|continue|default|unsafe|match|if|else|for|go|goto|defer|return)\\b"
+					"match": "\\b(as|it|is|in|or|break|continue|default|unsafe|match|if|else|for|go|goto|defer|return)\\b"
 				},
 				{
 					"name": "keyword.$1.v",
@@ -835,7 +835,7 @@
 				},
 				{
 					"name": "storage.type.$1.v",
-					"match": "\\b(bool|byte|byteptr|charptr|voidptr|string|ustring|rune|none)\\b"
+					"match": "\\b(bool|byte|byteptr|charptr|voidptr|string|ustring|rune)\\b"
 				}
 			]
 		},


### PR DESCRIPTION
BTW I haven't tested this, just looks right by inspection.
* missing `as` keyword
* `none` is listed with types (unlike `true`/`false` constants), it should be a constant: https://github.com/vlang/v/pull/5700#issuecomment-654383383