### PR TITLE
Add prompt when config changes needs restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,13 +77,13 @@
 					"scope": "resource",
 					"type": "boolean",
 					"default": true,
-					"description": "Whether to enable the linter. Changes require restart."
+					"description": "Whether to enable the linter."
 				},
 				"v.allowGlobals": {
 					"scope": "resource",
 					"type": "boolean",
 					"default": false,
-					"description": "Whether to enable global variables. Changes require restart."
+					"description": "Whether to enable global variables."
 				},
 				"v.vls.path": {
 					"scope": "resource",
@@ -95,7 +95,7 @@
 					"scope": "resource",
 					"type": "boolean",
 					"default": false,
-					"description": "Enable language server."
+					"description": "Enables the language server."
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -77,25 +77,25 @@
 					"scope": "resource",
 					"type": "boolean",
 					"default": true,
-					"description": "Whether to enable the linter."
+					"description": "Enables the linter. Restart is required to take effect."
 				},
 				"v.allowGlobals": {
 					"scope": "resource",
 					"type": "boolean",
 					"default": false,
-					"description": "Whether to enable global variables."
+					"description": "Enables support for global variables. Restart is required to take effect."
 				},
 				"v.vls.path": {
 					"scope": "resource",
 					"type": "string",
 					"default": "",
-					"description": "Path to the VLS (V Language Server) executable."
+					"description": "Path to the VLS (V Language Server) executable. Restart is required to take effect."
 				},
 				"v.vls.enable": {
 					"scope": "resource",
 					"type": "boolean",
 					"default": false,
-					"description": "Enables the language server."
+					"description": "Enables the language server. Restart is required to take effect."
 				}
 			}
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,11 @@ export function activate(context: vscode.ExtensionContext) {
 		context.subscriptions.push(disposable);
 	}
 
-	context.subscriptions.push(registerFormatter(), attachOnCloseTerminalListener());
+	context.subscriptions.push(
+		registerFormatter(),
+		attachOnCloseTerminalListener(),
+		vscode.workspace.onDidChangeConfiguration(didChangeConfiguration)
+	);
 
 	if (getWorkspaceConfig().get("enableLinter") && !getWorkspaceConfig().get("vls.enable")) {
 		// Make a temp folder for linter
@@ -39,8 +43,7 @@ export function activate(context: vscode.ExtensionContext) {
 		context.subscriptions.push(
 			vscode.window.onDidChangeVisibleTextEditors(didChangeVisibleTextEditors),
 			vscode.workspace.onDidSaveTextDocument(didSaveTextDocument),
-			vscode.workspace.onDidCloseTextDocument(didCloseTextDocument),
-			vscode.workspace.onDidChangeConfiguration(didChangeConfiguration)
+			vscode.workspace.onDidCloseTextDocument(didCloseTextDocument)
 		);
 		// If there are V files open, do the lint immediately
 		if (
@@ -93,7 +96,12 @@ function didCloseTextDocument(document: vscode.TextDocument) {
  */
 function didChangeConfiguration(event: vscode.ConfigurationChangeEvent) {
 	if (!event.affectsConfiguration("v")) return;
-	vscode.window.showWarningMessage("There's a new change in configuration and a restart is required.\n\nGo to Command Palette > Developer: Reload Window to restart your current window.");
+	vscode.window.showInformationMessage("There's a new change in configuration and a restart is required. Would you like to restart it now?", "Yes", "No")
+		.then(choice => {
+			if (choice == "Yes") {
+				vscode.commands.executeCommand("workbench.action.reloadWindow");
+			}
+		});
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,7 +39,8 @@ export function activate(context: vscode.ExtensionContext) {
 		context.subscriptions.push(
 			vscode.window.onDidChangeVisibleTextEditors(didChangeVisibleTextEditors),
 			vscode.workspace.onDidSaveTextDocument(didSaveTextDocument),
-			vscode.workspace.onDidCloseTextDocument(didCloseTextDocument)
+			vscode.workspace.onDidCloseTextDocument(didCloseTextDocument),
+			vscode.workspace.onDidChangeConfiguration(didChangeConfiguration)
 		);
 		// If there are V files open, do the lint immediately
 		if (
@@ -85,6 +86,14 @@ function didCloseTextDocument(document: vscode.TextDocument) {
 	if (document.languageId === vLanguageId) {
 		linter._delete(document.uri);
 	}
+}
+
+/**
+ *  Handles the `onDidChangeConfiguration` event
+ */
+function didChangeConfiguration(event: vscode.ConfigurationChangeEvent) {
+	if (!event.affectsConfiguration("v")) return;
+	vscode.window.showWarningMessage("There's a new change in configuration and a restart is required.\n\nGo to Command Palette > Developer: Reload Window to restart your current window.");
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,9 +33,8 @@ export function getVExecCommand(): string {
 
 /** Get V configuration. */
 export function getWorkspaceConfig(): WorkspaceConfiguration {
-	const currentDoc = getCurrentDocument();
-	const uri = currentDoc ? currentDoc.uri : null;
-	return workspace.getConfiguration("v", uri);
+	const currentWorkspaceFolder = getWorkspaceFolder();
+	return workspace.getConfiguration("v", currentWorkspaceFolder.uri);
 }
 
 /** Get current working directory.


### PR DESCRIPTION
This makes it also require all changed settings to have the current VSCode window be restarted for now*

\* VLS-related settings won't be required for a window restart in the next/future PR