### PR TITLE
Fix syntax highlighting for struct

### DIFF
--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -673,7 +673,7 @@
 			"patterns": [
 				{
 					"name": "meta.definition.struct.v",
-					"begin": "^\\s*(?:(mut|pub(?:\\s+mut)?|__global)\\s+)?(struct|union)\\s+([\\w.]+)\\s*({)",
+					"begin": "^\\s*(?:(mut|pub(?:\\s+mut)?|__global)\\s+)?(struct|union)\\s+([\\w.]+)\\s*|({)",
 					"beginCaptures": {
 						"1": {
 							"name": "storage.modifier.$1.v"
@@ -688,7 +688,7 @@
 							"name": "punctuation.definition.bracket.curly.begin.v"
 						}
 					},
-					"end": "\\s*(})",
+					"end": "\\s*|(})",
 					"endCaptures": {
 						"1": {
 							"name": "punctuation.definition.bracket.curly.end.v"


### PR DESCRIPTION
Now support multi line and struct without a bracket, eg: C struct definition

### Before
![struct-before-x](https://user-images.githubusercontent.com/16399020/103239651-33014300-4989-11eb-9ac2-cf09d4e07a28.png)

### After
![struct-after-x](https://user-images.githubusercontent.com/16399020/103239680-4ca28a80-4989-11eb-8ff8-f51c473a7b02.png)

### Before
![struct-before-x2](https://user-images.githubusercontent.com/16399020/103239724-68a62c00-4989-11eb-8af1-f9107775bf9e.png)

### After
![struct-after-x2](https://user-images.githubusercontent.com/16399020/103239746-7491ee00-4989-11eb-9c60-671e09ccd772.png)
