### PR TITLE
feat: added snippets for vweb

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -118,7 +118,7 @@
 	"snippet.fn.vweb_get_html": {
 		"body": [
 			"fn (mut app App) ${1:name}() vweb.Result {",
-			"\treturn $vweb.html()",
+			"\treturn \\$vweb.html()",
 			"}"
 		],
 		"description": "Code snippet for a vweb HTTP GET endpoint function which returns an HTML response",
@@ -151,7 +151,7 @@
 		"body": [
 			"[post]",
 			"fn (mut app App) ${1:name}() vweb.Result {",
-			"\treturn $vweb.html()",
+			"\treturn \\$vweb.html()",
 			"}"
 		],
 		"description": "Code snippet for a vweb HTTP POST endpoint function which returns an HTML response",
@@ -184,7 +184,7 @@
 		"body": [
 			"[patch]",
 			"fn (mut app App) ${1:name}() vweb.Result {",
-			"\treturn $vweb.html()",
+			"\treturn \\$vweb.html()",
 			"}"
 		],
 		"description": "Code snippet for a vweb HTTP PATCH endpoint function which returns an HTML response",
@@ -217,7 +217,7 @@
 		"body": [
 			"[put]",
 			"fn (mut app App) ${1:name}() vweb.Result {",
-			"\treturn $vweb.html()",
+			"\treturn \\$vweb.html()",
 			"}"
 		],
 		"description": "Code snippet for a vweb HTTP PUT endpoint function which returns an HTML response",
@@ -250,7 +250,7 @@
 		"body": [
 			"[delete]",
 			"fn (mut app App) ${1:name}() vweb.Result {",
-			"\treturn $vweb.html()",
+			"\treturn \\$vweb.html()",
 			"}"
 		],
 		"description": "Code snippet for a vweb HTTP DELETE endpoint function which returns an HTML response",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -95,6 +95,114 @@
 		"prefix": "prl",
 		"scope": "v,vlang"
 	},
+	"snippet.fn.vweb_get": {
+		"body": [
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\t${2:// TODO}",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP GET endpoint function",
+		"prefix": "vweb_get",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_get_json": {
+		"body": [
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\treturn app.json(${2:'response'})",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP GET endpoint function a JSON response",
+		"prefix": "vweb_get_json",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_post": {
+		"body": [
+			"[post]",
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\t${2:// TODO}",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP POST endpoint function",
+		"prefix": "vweb_post",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_post_json": {
+		"body": [
+			"[post]",
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\treturn app.json(${2:'response'})",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP POST endpoint function with a JSON response",
+		"prefix": "vweb_post_json",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_patch": {
+		"body": [
+			"[patch]",
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\t${2:// TODO}",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP PATCH endpoint function",
+		"prefix": "vweb_patch",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_patch_json": {
+		"body": [
+			"[patch]",
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\treturn app.json(${2:'response'})",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP PATCH endpoint function with a JSON response",
+		"prefix": "vweb_patch_json",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_put": {
+		"body": [
+			"[put]",
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\t${2:// TODO}",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP PUT endpoint function",
+		"prefix": "vweb_put",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_put_json": {
+		"body": [
+			"[put]",
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\treturn app.json(${2:'response'})",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP PUT endpoint function with a JSON response",
+		"prefix": "vweb_put_json",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_delete": {
+		"body": [
+			"[delete]",
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\t${2:// TODO}",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP DELETE endpoint function",
+		"prefix": "vweb_delete",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_delete_json": {
+		"body": [
+			"[delete]",
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\treturn app.json(${2:'response'})",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP DELETE endpoint function with a JSON response",
+		"prefix": "vweb_delete_json",
+		"scope": "v,vlang"
+	},
 	"snippet.for": {
 		"body": ["for {", "\t$0", "}"],
 		"description": "Code snippet for pure infinity loop 'for'",
@@ -207,6 +315,16 @@
 		"body": ["struct ${1:Name} {", "\t$0", "}"],
 		"description": "Code snippet for 'struct'",
 		"prefix": "stru",
+		"scope": "v,vlang"
+	},
+	"snippet.struct.vweb_app": {
+		"body": [
+			"struct ${1:App} {",
+			"\tvweb.Context",
+			"}"
+		],
+		"description": "Code snippet for a vweb.Context struct",
+		"prefix": "vweb_app",
 		"scope": "v,vlang"
 	},
 	"snippet.type": {

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -111,8 +111,18 @@
 			"\treturn app.json(${2:'response'})",
 			"}"
 		],
-		"description": "Code snippet for a vweb HTTP GET endpoint function a JSON response",
+		"description": "Code snippet for a vweb HTTP GET endpoint function which returns a JSON response",
 		"prefix": "vweb_get_json",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_get_html": {
+		"body": [
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\treturn $vweb.html()",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP GET endpoint function which returns an HTML response",
+		"prefix": "vweb_get_html",
 		"scope": "v,vlang"
 	},
 	"snippet.fn.vweb_post": {
@@ -133,8 +143,19 @@
 			"\treturn app.json(${2:'response'})",
 			"}"
 		],
-		"description": "Code snippet for a vweb HTTP POST endpoint function with a JSON response",
+		"description": "Code snippet for a vweb HTTP POST endpoint function which returns a JSON response",
 		"prefix": "vweb_post_json",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_post_html": {
+		"body": [
+			"[post]",
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\treturn $vweb.html()",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP POST endpoint function which returns an HTML response",
+		"prefix": "vweb_post_html",
 		"scope": "v,vlang"
 	},
 	"snippet.fn.vweb_patch": {
@@ -155,8 +176,19 @@
 			"\treturn app.json(${2:'response'})",
 			"}"
 		],
-		"description": "Code snippet for a vweb HTTP PATCH endpoint function with a JSON response",
+		"description": "Code snippet for a vweb HTTP PATCH endpoint function which returns a JSON response",
 		"prefix": "vweb_patch_json",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_patch_html": {
+		"body": [
+			"[patch]",
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\treturn $vweb.html()",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP PATCH endpoint function which returns an HTML response",
+		"prefix": "vweb_patch_html",
 		"scope": "v,vlang"
 	},
 	"snippet.fn.vweb_put": {
@@ -177,8 +209,19 @@
 			"\treturn app.json(${2:'response'})",
 			"}"
 		],
-		"description": "Code snippet for a vweb HTTP PUT endpoint function with a JSON response",
+		"description": "Code snippet for a vweb HTTP PUT endpoint function which returns a JSON response",
 		"prefix": "vweb_put_json",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_put_html": {
+		"body": [
+			"[put]",
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\treturn $vweb.html()",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP PUT endpoint function which returns an HTML response",
+		"prefix": "vweb_put_html",
 		"scope": "v,vlang"
 	},
 	"snippet.fn.vweb_delete": {
@@ -199,8 +242,19 @@
 			"\treturn app.json(${2:'response'})",
 			"}"
 		],
-		"description": "Code snippet for a vweb HTTP DELETE endpoint function with a JSON response",
+		"description": "Code snippet for a vweb HTTP DELETE endpoint function which returns a JSON response",
 		"prefix": "vweb_delete_json",
+		"scope": "v,vlang"
+	},
+	"snippet.fn.vweb_delete_html": {
+		"body": [
+			"[delete]",
+			"fn (mut app App) ${1:name}() vweb.Result {",
+			"\treturn $vweb.html()",
+			"}"
+		],
+		"description": "Code snippet for a vweb HTTP DELETE endpoint function which returns an HTML response",
+		"prefix": "vweb_delete_html",
 		"scope": "v,vlang"
 	},
 	"snippet.for": {

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -257,6 +257,26 @@
 		"prefix": "vweb_delete_html",
 		"scope": "v,vlang"
 	},
+	"snippet.vweb_skeleton": {
+		"body": [
+			"import vweb",
+			"",
+			"struct App {",
+			"\tvweb.Context",
+			"}",
+			"",
+			"fn main() {",
+			"\tvweb.run<App>(${1:8080})",
+			"}",
+			"",
+			"fn (mut app App) ${2:index}() vweb.Result {",
+			"\treturn app.json(${3:'response'})",
+			"}"
+		],
+		"description": "Code snippet to generate a very basic web server including all necessary elements",
+		"prefix": "vweb_skeleton",
+		"scope": "v,vlang"
+	},
 	"snippet.for": {
 		"body": ["for {", "\t$0", "}"],
 		"description": "Code snippet for pure infinity loop 'for'",


### PR DESCRIPTION
Added snippets to create the usual struct for vweb.Context and snippets for GET, POST, PUT, PATCH and DELETE endpoint functions.
This makes it much smoother to create Web APIs or websites in general.

Snippets:
- vweb_skeleton
- vweb_app
- vweb_get
- vweb_get_json
- vweb_get_html
- vweb_post
- vweb_post_json
- vweb_post_html
- vweb_patch
- vweb_patch_json
- vweb_patch_html
- vweb_put
- vweb_put_json
- vweb_put_html
- vweb_delete
- vweb_delete_json
- vweb_delete_html

## Preview
**vweb_skeleton:**
![image](https://user-images.githubusercontent.com/20150243/109727151-1fa26c00-7bb4-11eb-9823-b7bf496b38c8.png)

**vweb_app:**
![image](https://user-images.githubusercontent.com/20150243/109724272-a274f800-7baf-11eb-8957-78a775289a41.png)

**vweb_get:**
![image](https://user-images.githubusercontent.com/20150243/109724211-83766600-7baf-11eb-8424-d501b524db0d.png)

**vweb_patch_json:**
![image](https://user-images.githubusercontent.com/20150243/109724244-92f5af00-7baf-11eb-9797-ffc06b4194fe.png)

**vweb_get_html:**
![image](https://user-images.githubusercontent.com/20150243/109725773-eec13780-7bb1-11eb-98bf-daa81b2e93f5.png)
