### PR TITLE
vscode-vlang: add option to connect vls via tcp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -500,80 +500,6 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-			"integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/visitor-keys": "4.29.1"
-			},
-			"engines": {
-				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/types": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-			"integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
-			"dev": true,
-			"engines": {
-				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-			"integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/visitor-keys": "4.29.1",
-				"debug": "^4.3.1",
-				"globby": "^11.0.3",
-				"is-glob": "^4.0.1",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
-			},
-			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-			"integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "4.29.1",
-				"eslint-visitor-keys": "^2.0.0"
-			},
-			"engines": {
-				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
 		"node_modules/acorn": {
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -3232,47 +3158,6 @@
 						"eslint-visitor-keys": "^2.0.0"
 					}
 				}
-			}
-		},
-		"@typescript-eslint/scope-manager": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-			"integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/visitor-keys": "4.29.1"
-			}
-		},
-		"@typescript-eslint/types": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-			"integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
-			"dev": true
-		},
-		"@typescript-eslint/typescript-estree": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-			"integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/visitor-keys": "4.29.1",
-				"debug": "^4.3.1",
-				"globby": "^11.0.3",
-				"is-glob": "^4.0.1",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
-			}
-		},
-		"@typescript-eslint/visitor-keys": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-			"integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/types": "4.29.1",
-				"eslint-visitor-keys": "^2.0.0"
 			}
 		},
 		"acorn": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 					"scope": "resource",
 					"type": "string",
 					"default": "",
-					"description": "Custom path to the VLS (V Language Server) executable. Restart is required to take effect."
+					"description": "Custom path to the VLS (V Language Server) executable."
 				},
 				"v.vls.enable": {
 					"scope": "resource",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,29 @@
 					"scope": "resource",
 					"type": "string",
 					"description": "Disables specific language server features. Multiple values must be separated with a comma (,)."
+				},
+				"v.vls.connectionMode": {
+					"scope": "resource",
+					"type": "string",
+					"default": "stdio",
+					"enum": ["stdio", "tcp"],
+					"description": "Specify the mode to be used when connecting to VLS.",
+					"enumDescriptions": [
+						"Connects to the language server via standard input/output. (Default)",
+						"Connects to the language server via TCP"
+					]
+				},
+				"v.vls.tcpMode.port": {
+					"scope": "resource",
+					"type": "number",
+					"default": 5007,
+					"description": "Port to be used when connecting to the language server. (Only in TCP mode)"
+				},
+				"v.vls.tcpMode.useRemoteServer": {
+					"scope": "resource",
+					"default": false,
+					"type": "boolean",
+					"description": "Connect to a remote server instead of launching a new local process. (Only in TCP mode)"
 				}
 			}
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,10 +21,12 @@ export function activate(context: ExtensionContext): void {
 		context.subscriptions.push(disposable);
 	}
 
-	const restartVls = vscode.commands.registerCommand('v.vls.restart', async() => {
-		void vscode.window.showInformationMessage('Restarting VLS...');
-		await deactivateVls();
-		await activateVls(context);
+	const restartVls = vscode.commands.registerCommand('v.vls.restart', () => {
+		const restartMsg = vscode.window.setStatusBarMessage('Restarting VLS...', 3000);
+		deactivateVls()
+			.then(() => restartMsg.dispose())
+			.then(() => activateVls(context))
+			.catch((err) => vscode.window.showErrorMessage(err));
 	});
 
 	context.subscriptions.push(restartVls);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,12 @@ export function activate(context: ExtensionContext): void {
 			} else {
 				void deactivateVls();
 			}
+		} else if (e.affectsConfiguration('v.vls') && isVlsEnabled()) {
+			vscode.window.showInformationMessage('VLS: Restart is required for changes to take effect. Would you like to proceed?', 'Yes', 'No')
+				.then(selected => {
+					if (selected == 'No') return;
+					vscode.commands.executeCommand('v.vls.restart');
+				});
 		}
 	});
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,9 @@ export function activate(context: ExtensionContext): void {
 	const restartVls = vscode.commands.registerCommand('v.vls.restart', () => {
 		const restartMsg = vscode.window.setStatusBarMessage('Restarting VLS...', 3000);
 		deactivateVls()
-			.then(() => restartMsg.dispose())
+			.then(() => { 
+				restartMsg.dispose(); 
+			})
 			.then(() => activateVls(context))
 			.catch((err) => vscode.window.showErrorMessage(err));
 	});
@@ -39,10 +41,10 @@ export function activate(context: ExtensionContext): void {
 				void deactivateVls();
 			}
 		} else if (e.affectsConfiguration('v.vls') && isVlsEnabled()) {
-			vscode.window.showInformationMessage('VLS: Restart is required for changes to take effect. Would you like to proceed?', 'Yes', 'No')
+			void vscode.window.showInformationMessage('VLS: Restart is required for changes to take effect. Would you like to proceed?', 'Yes', 'No')
 				.then(selected => {
 					if (selected == 'No') return;
-					vscode.commands.executeCommand('v.vls.restart');
+					void vscode.commands.executeCommand('v.vls.restart');
 				});
 		}
 	});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 import vscode, { workspace, ExtensionContext, ConfigurationChangeEvent } from 'vscode';
 import * as commands from './commands';
-import { getWorkspaceConfig } from './utils';
-import { activateVls, deactivateVls } from './langserver';
+import { activateVls, deactivateVls, isVlsEnabled } from './langserver';
 
 const cmds = {
 	'v.run': commands.run,
@@ -32,8 +31,7 @@ export function activate(context: ExtensionContext): void {
 
 	workspace.onDidChangeConfiguration((e: ConfigurationChangeEvent) => {
 		if (e.affectsConfiguration('v.vls.enable')) {
-			const isVlsEnabled = getWorkspaceConfig().get<boolean>('vls.enable');
-			if (isVlsEnabled) {
+			if (isVlsEnabled()) {
 				void activateVls(context);
 			} else {
 				void deactivateVls();
@@ -41,7 +39,7 @@ export function activate(context: ExtensionContext): void {
 		}
 	});
 
-	const shouldEnableVls = getWorkspaceConfig().get<boolean>('vls.enable');
+	const shouldEnableVls = isVlsEnabled();
 	if (shouldEnableVls) {
 		void activateVls(context);
 	}

--- a/src/langserver.ts
+++ b/src/langserver.ts
@@ -39,6 +39,10 @@ export async function isVlsInstalled(): Promise<boolean> {
 	return await existsAsync(vlsPath);
 }
 
+export function isVlsEnabled(): boolean {
+	return getWorkspaceConfig().get<boolean>('vls.enable') ?? false;
+}
+
 export async function installVls(): Promise<void> {
 	try {
 		await window.withProgress({
@@ -151,6 +155,7 @@ export function connectVls(pathToVls: string, context: ExtensionContext): void {
 }
 
 export async function activateVls(context: ExtensionContext): Promise<void> {
+	if (!isVlsEnabled()) return;
 	const customVlsPath = getWorkspaceConfig().get<string>('vls.customPath');
 	if (!customVlsPath) {
 		// if no vls path is given, try to used the installed one or install it.
@@ -164,7 +169,7 @@ export async function activateVls(context: ExtensionContext): Promise<void> {
 }
 
 export async function deactivateVls(): Promise<void> {
-	if (!client) {
+	if (!client || !isVlsEnabled()) {
 		return;
 	}
 	await client.stop();


### PR DESCRIPTION
This PR enables connecting VLS via TCP.

## Notes
- Added safeguards to prevent restarting VLS when `VLS: Enable` checkbox is unchecked.
- Changes to VLS (with the exception of `VLS: Enable` setting) are subject to server restart. A dialog is presented on every after change.
- Restart VLS message is moved to the status bar.