### PR TITLE
vscode-vlang: update vls compilation command, fix restart command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,7 @@ export function activate(context: ExtensionContext): void {
 	workspace.onDidChangeConfiguration((e: ConfigurationChangeEvent) => {
 		if (e.affectsConfiguration('v.vls.enable')) {
 			if (isVlsEnabled()) {
-				void activateVls(context);
+				void activateVls();
 			} else {
 				void deactivateVls();
 			}
@@ -51,6 +51,6 @@ export function activate(context: ExtensionContext): void {
 
 	const shouldEnableVls = isVlsEnabled();
 	if (shouldEnableVls) {
-		void activateVls(context);
+		void activateVls();
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
-import vscode, { workspace, ExtensionContext, ConfigurationChangeEvent, ProgressLocation } from 'vscode';
+import vscode, { workspace, ExtensionContext, ConfigurationChangeEvent } from 'vscode';
 import * as commands from './commands';
 import { activateVls, deactivateVls, isVlsEnabled } from './langserver';
-import { outputChannel, vlsOutputChannel } from './status';
 
 const cmds = {
 	'v.run': commands.run,
@@ -9,6 +8,7 @@ const cmds = {
 	'v.prod': commands.prod,
 	'v.devbits_playground': commands.devbitsPlayground,
 	'v.vls.update': commands.updateVls,
+	'v.vls.restart': commands.restartVls,
 };
 
 /**
@@ -21,30 +21,6 @@ export function activate(context: ExtensionContext): void {
 		const disposable = vscode.commands.registerCommand(cmd, handler);
 		context.subscriptions.push(disposable);
 	}
-
-	const restartVls = vscode.commands.registerCommand('v.vls.restart', () => {
-		vscode.window.withProgress({
-			location: ProgressLocation.Notification,
-			cancellable: false,
-			title: 'VLS'
-		}, async (progress) => {
-			progress.report({ message: 'Restarting' });
-			await deactivateVls();
-			vlsOutputChannel.clear();
-			return await activateVls();
-		}).then(
-			() => {
-				return;
-			},
-			(err) => {
-				outputChannel.appendLine(err);
-				outputChannel.show();
-				void vscode.window.showErrorMessage('Failed restarting VLS. See output for more information.');
-			}
-		);
-	});
-
-	context.subscriptions.push(restartVls);
 
 	workspace.onDidChangeConfiguration((e: ConfigurationChangeEvent) => {
 		if (e.affectsConfiguration('v.vls.enable')) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import vscode, { workspace, ExtensionContext, ConfigurationChangeEvent } from 'vscode';
 import * as commands from './commands';
-import { activateVls, deactivateVls, isVlsEnabled } from './langserver';
+import { activateVls, deactivateVls, isVlsEnabled, terminateVlsProcess } from './langserver';
 
 const cmds = {
 	'v.run': commands.run,
@@ -28,6 +28,7 @@ export function activate(context: ExtensionContext): void {
 				void activateVls();
 			} else {
 				void deactivateVls();
+				void terminateVlsProcess();
 			}
 		} else if (e.affectsConfiguration('v.vls') && isVlsEnabled()) {
 			void vscode.window.showInformationMessage('VLS: Restart is required for changes to take effect. Would you like to proceed?', 'Yes', 'No')

--- a/src/langserver.ts
+++ b/src/langserver.ts
@@ -127,9 +127,7 @@ export function connectVls(pathToVls: string): void {
 	if (shouldSpawnProcess) {
 		// Kill first the existing VLS process
 		// before launching a new one.
-		if (typeof vlsProcess != 'undefined' && vlsProcess && !vlsProcess.killed) {
-			vlsProcess.kill();
-		}
+		terminateVlsProcess();
 
 		console.log('Spawning VLS process...');
 		vlsProcess = cp.spawn(pathToVls.trim(), vlsArgs);
@@ -163,7 +161,7 @@ export function connectVls(pathToVls: string): void {
 			window.setStatusBarMessage('The V language server failed to initialize.', 3000);
 		});
 
-	// NOTE: the language client was remove in the context subscription's
+	// NOTE: the language client was remove in the context subscriptions
 	// because of it's error-handling behavior which causes the progress/message
 	// box to hang and produce unnecessary errors in the output/devtools log.
 	client.start();
@@ -189,5 +187,11 @@ export async function activateVls(): Promise<void> {
 export async function deactivateVls(): Promise<void> {
 	if (client && isVlsEnabled()) {
 		return client.stop();
+	}
+}
+
+export function terminateVlsProcess(): void {
+	if (shouldSpawnProcess && typeof vlsProcess != 'undefined' && vlsProcess && !vlsProcess.killed) {
+		vlsProcess.kill();
 	}
 }

--- a/src/langserver.ts
+++ b/src/langserver.ts
@@ -18,7 +18,7 @@ const vlsDir = path.join(os.homedir(), '.vls');
 const vlsBin = path.join(vlsDir, 'bin');
 const vexe = getVExecCommand();
 const isWin = process.platform === 'win32';
-export const vlsPath = path.join(vlsBin, isWin ? 'vls.exe' : 'vls');
+export let vlsPath = path.join(vlsBin, isWin ? 'vls.exe' : 'vls');
 export let client: LanguageClient;
 let vlsProcess: cp.ChildProcess;
 let shouldSpawnProcess = true;
@@ -170,6 +170,9 @@ export async function activateVls(context: ExtensionContext): Promise<void> {
 			connectVls(vlsPath, context);
 		}
 	} else {
+		// It is very important to set this or start/stopping
+		// the VLS process won't work.
+		vlsPath = customVlsPath;
 		connectVls(customVlsPath, context);
 	}
 }

--- a/src/langserver.ts
+++ b/src/langserver.ts
@@ -8,7 +8,7 @@ import { window, ExtensionContext, workspace, ProgressLocation } from 'vscode';
 import { LanguageClient, LanguageClientOptions, StreamInfo, ServerOptions } from 'vscode-languageclient/node';
 
 import { getVExecCommand, getWorkspaceConfig } from './utils';
-import { outputChannel } from './status';
+import { outputChannel, vlsOutputChannel } from './status';
 
 const execAsync = util.promisify(cp.exec);
 const mkdirAsync = util.promisify(fs.mkdir);
@@ -139,6 +139,7 @@ export function connectVls(pathToVls: string, context: ExtensionContext): void {
 		synchronize: {
 			fileEvents: workspace.createFileSystemWatcher('**/*.v')
 		},
+		outputChannel: vlsOutputChannel
 	};
 
 	client = new LanguageClient(

--- a/src/langserver.ts
+++ b/src/langserver.ts
@@ -125,6 +125,12 @@ export function connectVls(pathToVls: string, context: ExtensionContext): void {
 	}
 
 	if (shouldSpawnProcess) {
+		// Kill first the existing VLS process
+		// before launching a new one.
+		if (typeof vlsProcess != 'undefined' && vlsProcess && !vlsProcess.killed) {
+			vlsProcess.kill();
+		}
+
 		console.log('Spawning VLS process...');
 		vlsProcess = cp.spawn(pathToVls.trim(), vlsArgs);
 	}
@@ -179,9 +185,6 @@ export async function activateVls(context: ExtensionContext): Promise<void> {
 
 export async function deactivateVls(): Promise<void> {
 	if (client && isVlsEnabled()) {
-		await client.stop();
-		if (shouldSpawnProcess && !vlsProcess.killed) {
-			vlsProcess.kill();
-		}
+		return client.stop();
 	}
 }

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,3 +1,4 @@
 import { window } from 'vscode';
 
 export const outputChannel = window.createOutputChannel('V');
+export const vlsOutputChannel = window.createOutputChannel('V Language Server');


### PR DESCRIPTION
This PR updates the command for compiling the VLS executable as well as fixing the behavior when restarting VLS. 

The latter should solve the errors such as duplicate server logs in the output tab, improper termination of "dead" VLS processes, and not starting the process on a user-provided VLS executable. However, this is not yet totally fixed as disabling VLS after initialization returns a "request failed" error. Another inclusion in this fix is the improved DX when restarting the language server.