### PR TITLE
vscode-vlang: fix vls process activation/deactivation

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,7 +1,7 @@
 import { window, env, Uri, ProgressLocation } from 'vscode';
 import { execVInTerminal, execV } from './exec';
 import { activateVls, deactivateVls, installVls } from './langserver';
-import { outputChannel, vlsOutputChannel } from './status';
+import { log, outputChannel, vlsOutputChannel } from './status';
 
 /** Run current file. */
 export async function run(): Promise<void> {
@@ -59,7 +59,7 @@ export function restartVls(): void {
 			return;
 		},
 		(err) => {
-			outputChannel.appendLine(err);
+			log(err);
 			outputChannel.show();
 			void window.showErrorMessage('Failed restarting VLS. See output for more information.');
 		}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -51,7 +51,7 @@ export function restartVls(): void {
 		title: 'VLS'
 	}, async (progress) => {
 		progress.report({ message: 'Restarting' });
-		await deactivateVls();
+		deactivateVls();
 		vlsOutputChannel.clear();
 		await activateVls();
 	}).then(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ export function activate(context: ExtensionContext): void {
 			if (isVlsEnabled()) {
 				void activateVls();
 			} else {
-				void deactivateVls();
+				deactivateVls();
 			}
 		} else if (e.affectsConfiguration('v.vls') && isVlsEnabled()) {
 			void vscode.window.showInformationMessage('VLS: Restart is required for changes to take effect. Would you like to proceed?', 'Yes', 'No')
@@ -45,6 +45,8 @@ export function activate(context: ExtensionContext): void {
 	}
 }
 
-export async function deactivate(): Promise<void> {
-	await deactivateVls();
+export function deactivate(): void {
+	if (isVlsEnabled()) {
+		deactivateVls();
+	}
 }

--- a/src/langserver.ts
+++ b/src/langserver.ts
@@ -122,8 +122,8 @@ export function connectVls(pathToVls: string): void {
 		pushArg(['--socket']);
 		pushArg(['--port'], tcpPort);
 
-		// This will instruct the client to not launch the VLS process
-		// and use an existing one with TCP enabled.
+		// This will instruct the extension to not skip launching
+		// a new VLS process and use an existing one with TCP enabled instead.
 		if (getWorkspaceConfig().get<boolean>('vls.tcpMode.useRemoteServer')) {
 			shouldSpawnProcess = false;
 		}
@@ -187,7 +187,7 @@ export function connectVls(pathToVls: string): void {
 			window.setStatusBarMessage('The V language server failed to initialize.', 3000);
 		});
 
-	// NOTE: the language client was remove in the context subscriptions
+	// NOTE: the language client was removed in the context subscriptions
 	// because of it's error-handling behavior which causes the progress/message
 	// box to hang and produce unnecessary errors in the output/devtools log.
 	clientDisposable = client.start();

--- a/src/langserver.ts
+++ b/src/langserver.ts
@@ -99,13 +99,13 @@ export function connectVls(pathToVls: string): void {
 	const vlsArgs: string[] = getWorkspaceConfig().get<string>('vls.customArgs').split(' ').filter(Boolean);
 	const hasArg = (flag: string): boolean => vlsArgs.findIndex(a => a == flag || a.startsWith(flag)) != -1;
 	const pushArg = (flags: string[], value?: string | number | boolean) => {
-		if ((typeof value == 'string' && value.length == 0) || value == null) {
+		if ((typeof value === 'string' && value.length == 0) || value === null) {
 			return;
 		}
-
+		
 		const validFlags = flags.filter(Boolean);
 		if (validFlags.length != 0 && validFlags.every(flag => !hasArg(flag))) {
-			if (typeof value == 'undefined' || (typeof value == 'boolean' && value)) {
+			if (typeof value === 'undefined' || (typeof value === 'boolean' && value)) {
 				vlsArgs.push(validFlags[0]);
 			} else {
 				vlsArgs.push(`${validFlags[0]}=${value.toString()}`);

--- a/src/langserver.ts
+++ b/src/langserver.ts
@@ -9,7 +9,7 @@ import { LanguageClient, LanguageClientOptions, StreamInfo, ServerOptions, Close
 import { terminate } from 'vscode-languageclient/lib/node/processes';
 
 import { getVExecCommand, getWorkspaceConfig } from './utils';
-import { outputChannel, vlsOutputChannel } from './status';
+import { log, outputChannel, vlsOutputChannel } from './status';
 
 const execAsync = util.promisify(cp.exec);
 const mkdirAsync = util.promisify(fs.mkdir);
@@ -74,7 +74,7 @@ export async function installVls(): Promise<void> {
 			await execAsync(`${vexe} -prod -o ${vlsPath} cmd/vls`, { maxBuffer: Infinity, cwd: vlsDir });
 		});
 	} catch (e) {
-		outputChannel.appendLine(e);
+		log(e);
 		outputChannel.show();
 		await window.showErrorMessage('Failed installing VLS. See output for more information.');
 	}
@@ -133,6 +133,7 @@ export function connectVls(pathToVls: string): void {
 		// Kill first the existing VLS process
 		// before launching a new one.
 		killVlsProcess();
+		log(`Spawning VLS process: ${pathToVls.trim()} ${vlsArgs.join(' ')}`);
 		vlsProcess = cp.spawn(pathToVls.trim(), vlsArgs);
 	}
 

--- a/src/status.ts
+++ b/src/status.ts
@@ -2,3 +2,9 @@ import { window } from 'vscode';
 
 export const outputChannel = window.createOutputChannel('V');
 export const vlsOutputChannel = window.createOutputChannel('V Language Server');
+
+export function log(msg: string): void {
+    // logging for devtools/debug
+    console.log(`[vscode-vlang] ${msg}`);
+    outputChannel.appendLine(msg);
+}


### PR DESCRIPTION
Fixes #336 

This PR moves the `shouldLaunchProcess` global variable inside the `connectVls` function. It also fixes the code for process deactivation both on window reload and on extension setting update. 

Also created a utility function for logging messages both in the output tab and in the developer tools / debug console for easy debugging.