### PR TITLE
[Fix 🐛]: Add the other commands to `activationEvents`

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,7 +219,13 @@
 	"activationEvents": [
 		"workspaceContains:**/*.v",
 		"onLanguage:v",
-		"onCommand:v.ver"
+		"onCommand:v.run",
+		"onCommand:v.fmt",
+		"onCommand:v.prod",
+		"onCommand:v.ver",
+		"onCommand:v.devbits_playground",
+		"onCommand:v.vls.update",
+		"onCommand:v.vls.restart"
 	],
 	"main": "./out/extension.js",
 	"dependencies": {


### PR DESCRIPTION
This PR adds all of the commands to the `activationEvents`, to avoid any errors arising from running a command when the extension hasn't activated