### PR TITLE
snippets: add unimplemented and unreachable asserts

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -5,6 +5,18 @@
 		"prefix": "as",
 		"scope": "v,vlang"
 	},
+	"snippet.unimpl": {
+		"body": ["assert false, unimplemented"],
+		"description": "Code snippet for unimplemented 'assert'",
+		"prefix": "unimpl",
+		"scope": "v,vlang"
+	},
+	"snippet.unreach": {
+		"body": ["assert false, unreachable"],
+		"description": "Code snippet for unreachable 'assert'",
+		"prefix": "unreach",
+		"scope": "v,vlang"
+	},
 	"snippet.break": {
 		"body": ["break$0"],
 		"description": "Code snippet for 'break'",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -6,13 +6,13 @@
 		"scope": "v,vlang"
 	},
 	"snippet.unimpl": {
-		"body": ["assert false, unimplemented"],
+		"body": ["assert false, 'unimplemented'"],
 		"description": "Code snippet for unimplemented 'assert'",
 		"prefix": "unimpl",
 		"scope": "v,vlang"
 	},
 	"snippet.unreach": {
-		"body": ["assert false, unreachable"],
+		"body": ["assert false, 'unreachable'"],
 		"description": "Code snippet for unreachable 'assert'",
 		"prefix": "unreach",
 		"scope": "v,vlang"


### PR DESCRIPTION
I want to add two snippets to the VSCode extension, I use these quite a lot.

### `snippet.unimpl`
```v
assert false, 'unimplemented'
```
### `snippet.unreach`
```v
assert false, 'unreachable'
```

Let me know if this is helpful!