### PR TITLE
Change format keybinding.

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
 		"keybindings": [
 			{
 				"command": "v.fmt",
-				"key": "ctrl+i ctrl+i"
+				"key": "ctrl+shift+i"
 			}
 		],
 		"commands": [


### PR DESCRIPTION
VS Code conventionally uses Ctrl+I for "trigger suggest" or inline chat and Ctrl+Shift+I for format. Note in particular that Copilot features revolve around the Ctrl+I shortcut.

https://code.visualstudio.com/docs/copilot/copilot-vscode-features

Further, the previous keybinding of "Ctrl+I Ctrl+I" starts a chord that has no other bindings.